### PR TITLE
Update lodash dependency from 4.17.11 to 4.17.15.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     },
     "dependencies": {
         "cannon": "0.6.2",
-        "lodash": "4.17.11",
+        "lodash": "4.17.15",
         "three": "0.100.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Hello,

I'm working on on a program analysis tool for some research and I noticed you are using version 4.17.11 of lodash. lodash@4.17.11 has a vulnerability in the defaultsDeep method which is used in this repository in src/constraints/VRHingeConstraint.ts.

This PR bumps the version of lodash to 4.17.15, the latest version as of this writing. I saw that all of your dependencies are pinned to specific versions and have respected that with this PR.

Let me know if you have any questions or would like to discuss further! Thanks!